### PR TITLE
fix(docs): Update Incorrect Documentation

### DIFF
--- a/doc_source/lambda.md
+++ b/doc_source/lambda.md
@@ -15,7 +15,7 @@ You indicate that an intent should use a Lambda function using the console or th
 
 ![\[The code hooks section of the Amazon Lex V2 intent editor.\]](http://docs.aws.amazon.com/lexv2/latest/dg/images/lambda-code-hooks.png)
 
-You define the Lambda function to use in each bot alias\. The same Lambda function is used for all intents in a language supported by the bot\. 
+You define the Lambda function to use in each bot alias\. The same Lambda function is used for all intents in a language supported by the bot\.
 
 **To choose a Lambda function to use with a bot alias**
 
@@ -105,7 +105,7 @@ The input format may change without a corresponding change to the `messageVersio
                 },
                 "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment",
                 "kendraResponse": {
-                    // Only present when intent is KendraSearchIntent. For details, see 
+                    // Only present when intent is KendraSearchIntent. For details, see
                     // https://docs.aws.amazon.com/kendra/latest/dg/API_Query.html#API_Query_ResponseSyntax
                 }
             },
@@ -149,6 +149,7 @@ The input format may change without a corresponding change to the `messageVersio
         "intent": {
             "confirmationState": "Confirmed | Denied | None",
             "name": "string",
+            "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment",
             "slots": {
                 "string": {
                     "value": {
@@ -192,7 +193,6 @@ The input format may change without a corresponding change to the `messageVersio
                     ]
                 }
             },
-            "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment",
             "kendraResponse": {
                 // Only present when intent is KendraSearchIntent. For details, see
                 // https://docs.aws.amazon.com/kendra/latest/dg/API_Query.html#API_Query_ResponseSyntax                     }
@@ -239,6 +239,7 @@ Amazon Lex V2 expects a response from your Lambda function in the following form
         "intent": {
             "confirmationState": "Confirmed | Denied | None",
             "name": "string",
+            "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment",
             "slots": {
                 "string": {
                     "value": {
@@ -282,8 +283,7 @@ Amazon Lex V2 expects a response from your Lambda function in the following form
                     ]
                 }
             }
-        },
-        "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment"
+        }
     },
     "messages": [
         {
@@ -312,7 +312,6 @@ Note the following additional information about the response fields:
 + **sessionState** – Required\. The current state of the conversation with the user\. The actual contents of the structure depends on the type of dialog action\.
   + **dialogAction** – Determines the type of action that Amazon Lex V2 should take in response to the Lambda function\. The `type` field is always required, the `slotToElicit` field is only required when `dialogAction.type` is `ElicitSlot`\.
   + **intent** – The name of the intent that Amazon Lex V2 should use\. Not required when `dialogAction.type` is `Delegate` or `ElicitIntent`\.
-  + **state** – Required\. The state can only be `ReadyForFulfillment` if `delegateAction.type` is `Delegate`\.
 + **messages** – Required if `dialogAction.type` is `ElicitIntent`\. One or more messages that Amazon Lex V2 shows to the customer to perform the next turn of the conversation\. If you don't supply messages, Amazon Lex V2 uses the appropriate message defined when the bot was created\. For more information, see the [Message](API_runtime_Message.md) data type\.
   + **contentType** – The type of message to use\.
   + **content** – If the message type is `PlainText`, `CustomPayload`, or `SSML`, the `content` field contains the message to send to the user\.


### PR DESCRIPTION
Hi There!

I'm hoping to submit a few documentation fixes for the Lex V2 Developer guide that caused me to do a fair bit of debugging today.

*Description of changes:*

1. The developer guide incorrectly references that the `state` property in Lambda input/output events is nested directly under the `sessionState` object. In reality, the `state` property is nested as follows:

```
    ...
    "sessionState": {
      "intent": {
        "state": "Failed | Fulfilled | InProgress | ReadyForFulfillment"
      }
    }
    ...
```

2. The developer guide references `delegateAction.type`, which is likely a typo for `dialogAction.type`. I removed the line as it's misleading though - it's possible to send a state of `InProgress` with a `Delegate` response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
