### PR TITLE
Fixing a period that needs to be a comma

### DIFF
--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -97,7 +97,9 @@ This example shows an example policy that allows IAM users to create and update 
         "iam:PassRole"
       ],
       "Effect": "Allow",
-      "Resource": ["arn:aws:lex:Region:123412341234:bot/*]
+        "Resource": [
+        "arn:aws:lex:us-east-2:055970264539:bot/*"
+        ]
     }
   ]
 }

--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -98,7 +98,7 @@ This example shows an example policy that allows IAM users to create and update 
       ],
       "Effect": "Allow",
         "Resource": [
-        "arn:aws:lex:us-east-2:055970264539:bot/*"
+        "arn:aws:lex:us-east-2:123412341234:bot/*"
         ]
     }
   ]

--- a/doc_source/security_iam_id-based-policy-examples.md
+++ b/doc_source/security_iam_id-based-policy-examples.md
@@ -93,7 +93,7 @@ This example shows an example policy that allows IAM users to create and update 
     {
       "Action": [
         "lex:CreateBot",
-        "lex:UpdateBot".
+        "lex:UpdateBot",
         "iam:PassRole"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
This minor thing tripped me up today, fixing a `.` that should be a `,`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
